### PR TITLE
Fix typos

### DIFF
--- a/modules/create-opf/xsl/create-opf.xsl
+++ b/modules/create-opf/xsl/create-opf.xsl
@@ -216,7 +216,7 @@
             <!-- accessibilityFeature -->
 
             <!-- only relative units used in CSS. also not texts should be available as images (like tables etc.) -->
-            <!-- To DO: constain check on font-sizes, otherwise box borders prevent feature. 
+            <!-- To DO: constrain check on font-sizes, otherwise box borders prevent feature. 
                  allowing to change fonts should be checked as well -->
             <xsl:variable name="accessibilityFeatures" as="element(*)*">
               <xsl:if test="not(/epub-config/metadata/meta[@property = 'schema:accessibilityFeature'][normalize-space(.) = 'displayTransformability']) 

--- a/modules/create-ops/xpl/create-ops.xpl
+++ b/modules/create-ops/xpl/create-ops.xpl
@@ -170,7 +170,7 @@
           <p:input port="source">
             <p:documentation>This stylesheet overwrites certain css:expand templates or variables.
               This is done because CSS3 isn't supported completely. In that stylesheet
-              text-decoration and other porperties can be changed to supported values. When CSS3 is
+              text-decoration and other properties can be changed to supported values. When CSS3 is
               supported it might be necessary to use this input port dynamically.</p:documentation>
             <p:document href="http://transpect.io/css-tools/xsl/css2-1-parser.xsl"/>
           </p:input>

--- a/modules/fontsubsetter/xpl/fontsubsetter.xpl
+++ b/modules/fontsubsetter/xpl/fontsubsetter.xpl
@@ -16,7 +16,7 @@
   
   <p:documentation>This pipeline creates fontsubsets. The characters used 
     in each font will be displayed in a character set. The subset is created 
-    using the pyftsubset phython script from fonttools https://github.com/fonttools.
+    using the pyftsubset python script from fonttools https://github.com/fonttools.
   </p:documentation>
   
   <p:option name="script-path" select="'../../../scripts/pyftsubset.sh'"/>
@@ -41,7 +41,7 @@
   </p:input>
   
   <p:output port="result" primary="true" sequence="true">
-    <p:documentation>Ouput is a character set displaying all characters used inside a font</p:documentation>
+    <p:documentation>Output is a character set displaying all characters used inside a font</p:documentation>
     <p:pipe port="result" step="viewport-chars-identity"/>
   </p:output>
   <p:serialization port="result" omit-xml-declaration="false" indent="true"/>

--- a/modules/html-splitter/xpl/html-splitter.xpl
+++ b/modules/html-splitter/xpl/html-splitter.xpl
@@ -84,7 +84,7 @@
   </p:variable>
 
   <p:identity name="strip-leading-non-elements">
-    <p:documentation>Strip spurious text-only document nodes that sometimes occured before the HTML
+    <p:documentation>Strip spurious text-only document nodes that sometimes occurred before the HTML
       document.</p:documentation>
     <p:input port="source" select="/html:html">
       <p:pipe port="source" step="html-splitter"/>

--- a/modules/html-splitter/xpl/split-css.xpl
+++ b/modules/html-splitter/xpl/split-css.xpl
@@ -11,7 +11,7 @@
   
   <p:documentation xmlns="http://www.w3.org/1999/xhtml">
     This pipeline is used to split the CSS based on the submitted value of the option <code>css-handling</code>.
-    With the value <code>regenerated-per-split</code>, the CSS is analyzed and splitted for each HTML chunk. Commonly 
+    With the value <code>regenerated-per-split</code>, the CSS is analyzed and split for each HTML chunk. Commonly 
     used CSS properties are stored to a global CSS stylesheet, whereas unused CSS properties are filtered.
     With the value <code>unchanged</code> CSS and HTML remain unchanged.
     Per default, a new CSS stylesheet is generated from the CSS XML representation.

--- a/modules/html-splitter/xsl/html-splitter.xsl
+++ b/modules/html-splitter/xsl/html-splitter.xsl
@@ -1001,7 +1001,7 @@
     <xsl:variable name="type-index" as="xs:integer" select="tr:index-of($same-type, ../@tr-epub-type)"/>
     <xsl:variable name="looked-up-name-component" select="$epub-config/types/type[@name = tr:epub-type(current()/../@tr-epub-type)]/(@file, @name)[1]" as="xs:string*"/>
     <xsl:if test="count($looked-up-name-component) gt 1">
-      <xsl:message select="concat('[WARNING] more than one occurence of epub type ', string-join($epub-config/types/type[@name = tr:epub-type(current()/../@tr-epub-type)][1]/@name, ''),   ' in config. First occurence is used for file name extraction.')"/>
+      <xsl:message select="concat('[WARNING] more than one occurrence of epub type ', string-join($epub-config/types/type[@name = tr:epub-type(current()/../@tr-epub-type)][1]/@name, ''),   ' in config. First occurrence is used for file name extraction.')"/>
     </xsl:if>
     <xsl:variable name="normalized" select="if ($looked-up-name-component[1]) 
                                             then $looked-up-name-component[1] 

--- a/modules/html-splitter/xsl/per-split-css.xsl
+++ b/modules/html-splitter/xsl/per-split-css.xsl
@@ -139,7 +139,7 @@
                                                    else concat($new-base-uri, $style-dir-name, '/', current-grouping-key())"/>
             <xsl:attribute name="common" select="'true'"/>
             <!--<xsl:apply-templates select="current-group()/self::css:atrule[@type = 'charset']"/>-->
-            <!-- Everything will be serialized as UTF-8 ayway, so no need to retain the initial declaration.
+            <!-- Everything will be serialized as UTF-8 anyway, so no need to retain the initial declaration.
             Neither do we have to declare it explicitly provided the including HTML file is also UTF-8. -->
             <xsl:variable name="css:utf8-charset" as="element(css:atrule)">
               <atrule xmlns="http://www.w3.org/1996/css" type="charset">

--- a/schema/metadata-conf/metadata-conf.rnc
+++ b/schema/metadata-conf/metadata-conf.rnc
@@ -258,7 +258,7 @@ types =
           ]
      }?
      & 
-       ## space separated list of epub:type values that will be pulled from secton/div to surrounding body
+       ## space separated list of epub:type values that will be pulled from section/div to surrounding body
        attribute pull-up-types {
          list { (landmark-types | "toc")+ }
        }?),

--- a/schema/metadata-conf/metadata-conf.rng
+++ b/schema/metadata-conf/metadata-conf.rng
@@ -445,7 +445,7 @@
         </optional>
         <optional>
           <attribute name="pull-up-types">
-            <a:documentation>space separated list of epub:type values that will be pulled from secton/div to surrounding body</a:documentation>
+            <a:documentation>space separated list of epub:type values that will be pulled from section/div to surrounding body</a:documentation>
             <list>
               <oneOrMore>
                 <choice>

--- a/xpl/epub-convert.xpl
+++ b/xpl/epub-convert.xpl
@@ -23,7 +23,7 @@
     on Unixy systems. For bash, this is, e.g., <code>source=file:/$(cygpath -ma sample/b978-3-646-92351-3.xhtml)</code> </p>
     <p>8/2023: new feature: if HTML contains a &gt;div>, &gt;section> or &gt;nav> element with <pre>@class="as-nav"</pre> and 
       <pre>@epub:type="loi"</pre> (or "lot") that section is removed from content and moved into the navigation page as &gt;nav> element.
-      This works not for EPUB2. Structure is expexted as &gt;ol>&gt;li>&gt;a href="link-to-fig">Fig 1: xyz&gt;/a>&gt;/li>&gt;/ol>.</p>
+      This works not for EPUB2. Structure is expected as &gt;ol>&gt;li>&gt;a href="link-to-fig">Fig 1: xyz&gt;/a>&gt;/li>&gt;/ol>.</p>
   </p:documentation>
 
   <p:serialization port="result" method="xml" encoding="UTF-8" indent="true" omit-xml-declaration="false"/>


### PR DESCRIPTION
Found via `codespell -S ./schematron -L ist,elemente,oder`